### PR TITLE
Enhance file filtering with default ignore patterns and support for CSS files

### DIFF
--- a/zlipy/domain/filesfilter/factory.py
+++ b/zlipy/domain/filesfilter/factory.py
@@ -16,10 +16,22 @@ class FilesFilterFactory:
         ignore_patterns: list[str] | None = None,
     ) -> IFilesFilter:
         if files_filter_type == FilesFilterTypes.DEFAULT:
+            if not ignore_patterns:
+                ignore_patterns = [
+                    "deeplake/",
+                    "zlipy.ini",
+                    "*.log",
+                    "*.sql",
+                    "*.json",
+                    "*.csv",
+                    "*.xml",
+                    "*.txt",
+                ]
+
             return MergeFilesFilter(
                 GitIgnoreFilesFilter(GITIGNORE_FILENAME),
                 AllowedExtensionsFilesFilter(),
-                IgnoredFilesFilter(ignore_patterns or []),
+                IgnoredFilesFilter(patterns=ignore_patterns),
             )
 
         if files_filter_type == FilesFilterTypes.GITIGNORE:


### PR DESCRIPTION
This pull request includes significant changes to the `zlipy/domain/filesfilter` module, improving the handling of ignored file patterns and simplifying the codebase. The most important changes include adding default ignore patterns, refactoring the `IgnoredFilesFilter` class to use match functions instead of regex, and updating imports to support these changes.

### Improvements to file filtering:

* [`zlipy/domain/filesfilter/factory.py`](diffhunk://#diff-5710f00867609c8d829641e8f45e671b006d20420a35b42679d3db3801c72fc6R19-R34): Added default ignore patterns for various file types when `ignore_patterns` is not provided.

### Codebase simplification:

* [`zlipy/domain/filesfilter/filters.py`](diffhunk://#diff-86dabd5b7de622cbc9b17ecc421dcaf4e5ea5386ef3a21398050ddd7a1b9c45fL81-R103): Refactored the `IgnoredFilesFilter` class to use match functions instead of regex patterns for ignoring files, improving readability and maintainability.
* [`zlipy/domain/filesfilter/filters.py`](diffhunk://#diff-86dabd5b7de622cbc9b17ecc421dcaf4e5ea5386ef3a21398050ddd7a1b9c45fL81-R103): Updated the `IgnoredFilesFilter` class to handle negation rules more effectively by leveraging the `handle_negation` function from `gitignore_parser`.
* [`zlipy/domain/filesfilter/filters.py`](diffhunk://#diff-86dabd5b7de622cbc9b17ecc421dcaf4e5ea5386ef3a21398050ddd7a1b9c45fL4-R7): Added a new import for `IgnoreRule`, `handle_negation`, and `rule_from_pattern` from `gitignore_parser` to support the refactoring.

### Additional changes:

* [`zlipy/domain/filesfilter/filters.py`](diffhunk://#diff-86dabd5b7de622cbc9b17ecc421dcaf4e5ea5386ef3a21398050ddd7a1b9c45fR43): Added support for `.css` files in the list of default file extensions.